### PR TITLE
Add com.google.wear.ACTION_SHOW_LICENSE action 

### DIFF
--- a/ui-wear-compose-material/src/main/AndroidManifest.xml
+++ b/ui-wear-compose-material/src/main/AndroidManifest.xml
@@ -4,6 +4,13 @@
   <application>
     <activity
       android:name=".WearableOssLicensesActivity"
-      android:exported="false" />
+      android:taskAffinity=".licenses"
+      android:theme="@android:style/Theme.DeviceDefault"
+      android:exported="true">
+      <intent-filter>
+        <action android:name="com.google.wear.ACTION_SHOW_LICENSE" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+    </activity>
   </application>
 </manifest>

--- a/ui-wear-compose-material3/src/main/AndroidManifest.xml
+++ b/ui-wear-compose-material3/src/main/AndroidManifest.xml
@@ -4,6 +4,13 @@
   <application>
     <activity
       android:name=".WearableOssLicensesActivity"
-      android:exported="false" />
+      android:taskAffinity=".licenses"
+      android:theme="@android:style/Theme.DeviceDefault"
+      android:exported="true">
+      <intent-filter>
+        <action android:name="com.google.wear.ACTION_SHOW_LICENSE" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+    </activity>
   </application>
 </manifest>


### PR DESCRIPTION
The com.google.wear.ACTION_SHOW_LICENSE is supported on some modern devices and will add a link to the App Info screen in Settings. Add to WearableOssLicensesActivity.

![image](https://github.com/user-attachments/assets/4ddf0ef2-70a1-4551-8016-9e90a61130ec)
