### PR TITLE
Improve gradle configuration for testing release builds

### DIFF
--- a/sample-wear/build.gradle.kts
+++ b/sample-wear/build.gradle.kts
@@ -28,6 +28,9 @@ android {
       isMinifyEnabled = true
       isShrinkResources = true
       proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+
+      // Allow testing the release build type with `./gradlew sample-wear:installRelease`
+      signingConfig = signingConfigs.getByName("debug")
     }
   }
 


### PR DESCRIPTION
Allow testing the release build type with `./gradlew sample-wear:installRelease` by setting `signingConfig` to debug for release builds.