### PR TITLE
Mark WearableOssLicensesActivity in `wear-ui` as deprecated

### DIFF
--- a/ui-wear/src/main/java/com/github/droibit/oss_licenses/ui/wear/WearableOssLicensesActivity.kt
+++ b/ui-wear/src/main/java/com/github/droibit/oss_licenses/ui/wear/WearableOssLicensesActivity.kt
@@ -12,6 +12,7 @@ import com.github.droibit.oss_licenses.ui.wear.internal.OssLicenseListFragment
 /**
  * An activity that displays open source licenses.
  */
+@Deprecated(message = "Please migrate to the Wear Compose version of WearableOssLicensesActivity.")
 class WearableOssLicensesActivity : FragmentActivity(R.layout.activity_wearable_oss_licenses) {
   private val viewModel: OssLicenseViewModel by viewModels()
 
@@ -37,6 +38,8 @@ class WearableOssLicensesActivity : FragmentActivity(R.layout.activity_wearable_
      * @param ignoreLibraries A set of library names to be ignored when displaying the licenses. Default is an empty set.
      * @return An [Intent] that can be used to start the [WearableOssLicensesActivity].
      */
+    @Suppress("DeprecatedCallableAddReplaceWith")
+    @Deprecated(message = "Please migrate to the Wear Compose version of WearableOssLicensesActivity.")
     @JvmStatic
     @JvmOverloads
     fun createIntent(


### PR DESCRIPTION
I am deprecating the `wear-ui` module as I will be focusing solely on officially recommended Jetpack Compose for Wear OS moving forward.

Future plans:
- The next version will generate a compile-time warning.
- The version after that will generate a compile error.
- In the version after that, the wear-ui module will be removed.
