### PR TITLE
Remove `ignoreLibraries` option for consistent license display behavior across launch methods

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,6 @@ androidx-fragment = { module = "androidx.fragment:fragment-ktx", version = "1.8.
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewModel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle" }
-androidx-lifecycle-viewModel-savedstate = { module = "androidx.lifecycle:lifecycle-viewmodel-savedstate", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewModel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidx-navigation" }
 androidx-recyclerView = { module = "androidx.recyclerview:recyclerview", version = "1.4.0" }
@@ -69,10 +68,6 @@ androidx-wear-compose-material3 = [
 androidx-wear-compose-navigation = [
   "androidx-navigation-compose",
   "androidx-wear-compose-navigation",
-]
-androidx-lifecycle-viewModel = [
-  "androidx-lifecycle-viewModel",
-  "androidx-lifecycle-viewModel-savedstate",
 ]
 androidx-lifecycle-viewModel-compose = [
   "androidx-lifecycle-viewModel-compose",

--- a/sample-wear/src/main/java/com/github/droibit/oss_licenses/sample/MainActivity.kt
+++ b/sample-wear/src/main/java/com/github/droibit/oss_licenses/sample/MainActivity.kt
@@ -12,21 +12,6 @@ import com.github.droibit.oss_licenses.ui.wear.compose.material3.WearableOssLice
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.compose.layout.AppScaffold
 
-private val IgnoreLibraries = setOf(
-  "kotlinx-coroutines-bom",
-  "Android Tracing",
-  "Animal Sniffer",
-  "Checker Framework Annotations",
-  "Error Prone",
-  "Guava JDK5",
-  "Guava JDK7",
-  "J2ObjC",
-  "JSR 305",
-  "JsInterop Annotations",
-  "apksig",
-  "JSpecify",
-)
-
 @OptIn(ExperimentalHorologistApi::class)
 class MainActivity : FragmentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -44,20 +29,9 @@ class MainActivity : FragmentActivity() {
 
   private fun onItemClick(uiType: UiComponentType) {
     val intent = when (uiType) {
-      UiComponentType.ANDROID_VIEW -> WearableOssLicensesActivity.createIntent(
-        this,
-        IgnoreLibraries,
-      )
-
-      UiComponentType.COMPOSE_M2 -> WearableM2OssLicensesActivity.createIntent(
-        this,
-        IgnoreLibraries,
-      )
-
-      UiComponentType.COMPOSE_M3 -> WearableM3OssLicensesActivity.createIntent(
-        this,
-        IgnoreLibraries,
-      )
+      UiComponentType.ANDROID_VIEW -> WearableOssLicensesActivity.createIntent(this)
+      UiComponentType.COMPOSE_M2 -> WearableM2OssLicensesActivity.createIntent(this)
+      UiComponentType.COMPOSE_M3 -> WearableM3OssLicensesActivity.createIntent(this)
     }
     startActivity(intent)
   }

--- a/ui-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/compose/material3/OssLicensesActivity.kt
+++ b/ui-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/compose/material3/OssLicensesActivity.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import com.github.droibit.oss_licenses.ui.compose.material3.internal.OssLicenseNavGraph
-import com.github.droibit.oss_licenses.ui.viewmodel.OssLicenseViewModel.Companion.EXTRA_IGNORE_LIBRARIES
 
 /**
  * An activity that displays open source licenses.
@@ -34,15 +33,9 @@ class OssLicensesActivity : ComponentActivity() {
     /**
      * Creates an [Intent] to start the [OssLicensesActivity].
      *
-     * @param ignoreLibraries A set of library names to be ignored when displaying the licenses. Default is an empty set.
      * @return An [Intent] that can be used to start the [OssLicensesActivity].
      */
     @JvmStatic
-    @JvmOverloads
-    fun createIntent(
-      context: Context,
-      ignoreLibraries: Set<String> = emptySet(),
-    ): Intent = Intent(context, OssLicensesActivity::class.java)
-      .putStringArrayListExtra(EXTRA_IGNORE_LIBRARIES, ArrayList(ignoreLibraries))
+    fun createIntent(context: Context): Intent = Intent(context, OssLicensesActivity::class.java)
   }
 }

--- a/ui-viewmodel/build.gradle.kts
+++ b/ui-viewmodel/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
   api(projects.parser)
 
   implementation(libs.kotlin.coroutines.core)
-  implementation(libs.bundles.androidx.lifecycle.viewModel)
+  implementation(libs.androidx.lifecycle.viewModel)
 }
 
 apply(from = "$rootDir/gradle/gradle-mvn-push.gradle.kts")

--- a/ui-viewmodel/src/main/java/com/github/droibit/oss_licenses/ui/viewmodel/OssLicenseViewModel.kt
+++ b/ui-viewmodel/src/main/java/com/github/droibit/oss_licenses/ui/viewmodel/OssLicenseViewModel.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.annotation.RestrictTo
 import androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP
 import androidx.annotation.UiThread
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.github.droibit.oss_licenses.parser.OssLicense
@@ -19,7 +18,6 @@ import kotlinx.coroutines.withContext
 @RestrictTo(LIBRARY_GROUP)
 class OssLicenseViewModel(
   private val parser: OssLicenseParser,
-  private val ignoreLibraries: Set<String>,
   private val dispatcher: CoroutineDispatcher,
   private val licensesSink: MutableStateFlow<List<OssLicense>>,
 ) : ViewModel() {
@@ -28,11 +26,8 @@ class OssLicenseViewModel(
     get() = licensesSink
 
   @Suppress("unused")
-  constructor(
-    savedStateHandle: SavedStateHandle,
-  ) : this(
+  constructor() : this(
     OssLicenseParser(),
-    savedStateHandle.getStringSet(EXTRA_IGNORE_LIBRARIES),
     Dispatchers.IO,
     licensesSink = MutableStateFlow(emptyList()),
   )
@@ -43,7 +38,7 @@ class OssLicenseViewModel(
         return@launch
       }
       licensesSink.value = withContext(dispatcher) {
-        parser.parse(context, ignoreLibraries)
+        parser.parse(context)
       }
     }
   }
@@ -52,14 +47,4 @@ class OssLicenseViewModel(
   fun getLicense(name: String): OssLicense {
     return licenses.value.first { it.libraryName == name }
   }
-
-  companion object {
-    const val EXTRA_IGNORE_LIBRARIES =
-      "com.github.droibit.oss_licenses.ui.viewomdel.EXTRA_IGNORE_LIBRARIES"
-  }
-}
-
-private fun SavedStateHandle.getStringSet(key: String): Set<String> {
-  val value = get<List<String>>(key)
-  return value?.toSet() ?: emptySet()
 }

--- a/ui-wear-compose-material/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material/WearableOssLicensesActivity.kt
+++ b/ui-wear-compose-material/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material/WearableOssLicensesActivity.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.wear.compose.material.MaterialTheme
-import com.github.droibit.oss_licenses.ui.viewmodel.OssLicenseViewModel.Companion.EXTRA_IGNORE_LIBRARIES
 import com.github.droibit.oss_licenses.ui.wear.compose.material.internal.OssLicenseNavGraph
 
 /**
@@ -27,15 +26,10 @@ class WearableOssLicensesActivity : ComponentActivity() {
     /**
      * Creates an [Intent] to start the [WearableOssLicensesActivity].
      *
-     * @param ignoreLibraries A set of library names to be ignored when displaying the licenses. Default is an empty set.
      * @return An [Intent] that can be used to start the [WearableOssLicensesActivity].
      */
     @JvmStatic
-    @JvmOverloads
-    fun createIntent(
-      context: Context,
-      ignoreLibraries: Set<String> = emptySet(),
-    ): Intent = Intent(context, WearableOssLicensesActivity::class.java)
-      .putStringArrayListExtra(EXTRA_IGNORE_LIBRARIES, ArrayList(ignoreLibraries))
+    fun createIntent(context: Context): Intent =
+      Intent(context, WearableOssLicensesActivity::class.java)
   }
 }

--- a/ui-wear-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material3/WearableOssLicensesActivity.kt
+++ b/ui-wear-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material3/WearableOssLicensesActivity.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.wear.compose.material3.MaterialTheme
-import com.github.droibit.oss_licenses.ui.viewmodel.OssLicenseViewModel.Companion.EXTRA_IGNORE_LIBRARIES
 import com.github.droibit.oss_licenses.ui.wear.compose.material3.internal.OssLicenseNavGraph
 
 /**
@@ -27,15 +26,10 @@ class WearableOssLicensesActivity : ComponentActivity() {
     /**
      * Creates an [Intent] to start the [WearableOssLicensesActivity].
      *
-     * @param ignoreLibraries A set of library names to be ignored when displaying the licenses. Default is an empty set.
      * @return An [Intent] that can be used to start the [WearableOssLicensesActivity].
      */
     @JvmStatic
-    @JvmOverloads
-    fun createIntent(
-      context: Context,
-      ignoreLibraries: Set<String> = emptySet(),
-    ): Intent = Intent(context, WearableOssLicensesActivity::class.java)
-      .putStringArrayListExtra(EXTRA_IGNORE_LIBRARIES, ArrayList(ignoreLibraries))
+    fun createIntent(context: Context): Intent =
+      Intent(context, WearableOssLicensesActivity::class.java)
   }
 }

--- a/ui-wear/src/main/java/com/github/droibit/oss_licenses/ui/wear/WearableOssLicensesActivity.kt
+++ b/ui-wear/src/main/java/com/github/droibit/oss_licenses/ui/wear/WearableOssLicensesActivity.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.fragment.app.FragmentActivity
 import com.github.droibit.oss_licenses.ui.viewmodel.OssLicenseViewModel
-import com.github.droibit.oss_licenses.ui.viewmodel.OssLicenseViewModel.Companion.EXTRA_IGNORE_LIBRARIES
 import com.github.droibit.oss_licenses.ui.wear.internal.OssLicenseListFragment
 
 /**
@@ -35,17 +34,12 @@ class WearableOssLicensesActivity : FragmentActivity(R.layout.activity_wearable_
     /**
      * Creates an [Intent] to start the [WearableOssLicensesActivity].
      *
-     * @param ignoreLibraries A set of library names to be ignored when displaying the licenses. Default is an empty set.
      * @return An [Intent] that can be used to start the [WearableOssLicensesActivity].
      */
     @Suppress("DeprecatedCallableAddReplaceWith")
     @Deprecated(message = "Please migrate to the Wear Compose version of WearableOssLicensesActivity.")
     @JvmStatic
-    @JvmOverloads
-    fun createIntent(
-      context: Context,
-      ignoreLibraries: Set<String> = emptySet(),
-    ): Intent = Intent(context, WearableOssLicensesActivity::class.java)
-      .putStringArrayListExtra(EXTRA_IGNORE_LIBRARIES, ArrayList(ignoreLibraries))
+    fun createIntent(context: Context): Intent =
+      Intent(context, WearableOssLicensesActivity::class.java)
   }
 }


### PR DESCRIPTION
This better aligns with Wear OS's built-in license display functionality through `com.google.wear.ACTION_SHOW_LICENSE` action.

Note that `OssLicenseParser` may still be used independently, so it will continue to accept the `ignoreLibraries` parameter.