### PR TITLE
Use explicit `@OptIn` annotations for `ExperimentalMaterial3Api`

### DIFF
--- a/sample-mobile/build.gradle.kts
+++ b/sample-mobile/build.gradle.kts
@@ -37,13 +37,6 @@ android {
     compose = true
     buildConfig = true
   }
-
-  kotlinOptions {
-    freeCompilerArgs = listOf(
-      *freeCompilerArgs.toTypedArray(),
-      "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api"
-    )
-  }
 }
 
 dependencies {

--- a/sample-mobile/src/main/java/com/github/droibit/oss_licenses/sample/MainActivity.kt
+++ b/sample-mobile/src/main/java/com/github/droibit/oss_licenses/sample/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.ui.Alignment
@@ -18,6 +19,7 @@ import androidx.compose.ui.res.stringResource
 import com.github.droibit.oss_licenses.sample.ui.Theme
 import com.github.droibit.oss_licenses.ui.compose.material3.OssLicensesActivity
 
+@OptIn(ExperimentalMaterial3Api::class)
 class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     enableEdgeToEdge()

--- a/sample-wear/build.gradle.kts
+++ b/sample-wear/build.gradle.kts
@@ -38,14 +38,6 @@ android {
     compose = true
     buildConfig = true
   }
-
-  kotlinOptions {
-    freeCompilerArgs = listOf(
-      *freeCompilerArgs.toTypedArray(),
-      "-opt-in=androidx.wear.compose.material.ExperimentalWearMaterialApi",
-      "-opt-in=androidx.compose.ui.ExperimentalComposeUiApi",
-    )
-  }
 }
 
 dependencies {

--- a/ui-compose-material3/build.gradle.kts
+++ b/ui-compose-material3/build.gradle.kts
@@ -18,12 +18,6 @@ android {
     compose = true
   }
 
-  kotlinOptions {
-    freeCompilerArgs = listOf(
-      *freeCompilerArgs.toTypedArray(),
-      "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api"
-    )
-  }
 
   packaging {
     resources {

--- a/ui-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/compose/material3/internal/OssLicenseDetailScreen.kt
+++ b/ui-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/compose/material3/internal/OssLicenseDetailScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -17,6 +18,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.github.droibit.oss_licenses.parser.OssLicense
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun OssLicenseDetailScreen(
   license: OssLicense,

--- a/ui-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/compose/material3/internal/OssLicenseListScreen.kt
+++ b/ui-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/compose/material3/internal/OssLicenseListScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.Scaffold
@@ -18,6 +19,7 @@ import com.github.droibit.oss_licenses.parser.OssLicense
 import com.github.droibit.oss_licenses.ui.compose.OssLicenseCollection
 import com.github.droibit.oss_licenses.ui.compose.material3.R
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun OssLicenseListScreen(
   licenses: OssLicenseCollection,


### PR DESCRIPTION
Replace build-level opt-in with explicit `@OptIn` annotations to improve code readability and make experimental API usage more transparent.
