### PR TITLE
Rename `libraryName` property to `library` in `OssLicense`

### DIFF
--- a/parser/src/main/java/com/github/droibit/oss_licenses/parser/OssLicense.kt
+++ b/parser/src/main/java/com/github/droibit/oss_licenses/parser/OssLicense.kt
@@ -6,11 +6,11 @@ import android.os.Parcelable
 /**
  * Represents a third-party library and its license.
  *
- * @param libraryName The name of the third-party library.
+ * @param library The name of the third-party library.
  * @param text The license of the third-party library.
  */
 data class OssLicense(
-  val libraryName: String,
+  val library: String,
   val text: String,
 ) : Comparable<OssLicense>, Parcelable {
 
@@ -19,12 +19,12 @@ data class OssLicense(
   }
 
   override fun writeToParcel(dest: Parcel, flags: Int) {
-    dest.writeString(libraryName)
+    dest.writeString(library)
     dest.writeString(text)
   }
 
   override fun compareTo(other: OssLicense): Int {
-    return libraryName.compareTo(other.libraryName, ignoreCase = true)
+    return library.compareTo(other.library, ignoreCase = true)
   }
 
   companion object CREATOR : Parcelable.Creator<OssLicense?> {

--- a/parser/src/main/java/com/github/droibit/oss_licenses/parser/OssLicenseParser.kt
+++ b/parser/src/main/java/com/github/droibit/oss_licenses/parser/OssLicenseParser.kt
@@ -66,7 +66,7 @@ class OssLicenseParser(
     val licenseBytes = licensesSource.buffer().use(BufferedSource::readByteString)
     return@withContext licensesMetadataSource.buffer().use { source ->
       val ossLicenses = sortedSetOf(
-        compareBy(String.CASE_INSENSITIVE_ORDER, OssLicense::libraryName),
+        compareBy(String.CASE_INSENSITIVE_ORDER, OssLicense::library),
       )
       while (!source.exhausted()) {
         ensureActive()

--- a/parser/src/test/java/com/github/droibit/oss_licenses/parser/OssLicenseParserTest.kt
+++ b/parser/src/test/java/com/github/droibit/oss_licenses/parser/OssLicenseParserTest.kt
@@ -104,43 +104,43 @@ class OssLicenseParserTest {
     val result = parser.parseInternal(licensesSource, licenseMetadataSource)
     assertThat(result).containsExactly(
       OssLicense(
-        libraryName = "Android Lifecycle Kotlin Extensions",
+        library = "Android Lifecycle Kotlin Extensions",
         text = "http://www.apache.org/licenses/LICENSE-2.0.txt",
       ),
       OssLicense(
-        libraryName = "Compose Animation Core",
+        library = "Compose Animation Core",
         text = "http://www.apache.org/licenses/LICENSE-2.0.txt",
       ),
       OssLicense(
-        libraryName = "Compose Tooling Data",
+        library = "Compose Tooling Data",
         text = "http://www.apache.org/licenses/LICENSE-2.0.txt",
       ),
       OssLicense(
-        libraryName = "Compose UI",
+        library = "Compose UI",
         text = "http://www.apache.org/licenses/LICENSE-2.0.txt",
       ),
       OssLicense(
-        libraryName = "Compose Util",
+        library = "Compose Util",
         text = "http://www.apache.org/licenses/LICENSE-2.0.txt",
       ),
       OssLicense(
-        libraryName = "Dagger",
+        library = "Dagger",
         text = "https://www.apache.org/licenses/LICENSE-2.0.txt",
       ),
       OssLicense(
-        libraryName = "JetBrains Java Annotations",
+        library = "JetBrains Java Annotations",
         text = "https://www.apache.org/licenses/LICENSE-2.0.txt",
       ),
       OssLicense(
-        libraryName = "kotlinx-coroutines-android",
+        library = "kotlinx-coroutines-android",
         text = "https://www.apache.org/licenses/LICENSE-2.0.txt",
       ),
       OssLicense(
-        libraryName = "kotlinx-coroutines-bom",
+        library = "kotlinx-coroutines-bom",
         text = "https://www.apache.org/licenses/LICENSE-2.0.txt",
       ),
       OssLicense(
-        libraryName = "kotlinx-coroutines-core",
+        library = "kotlinx-coroutines-core",
         text = "https://www.apache.org/licenses/LICENSE-2.0.txt",
       ),
     ).inOrder()

--- a/ui-compose-material3/src/debug/java/com/github/droibit/oss_licenses/ui/compose/material3/internal/OssLicenseDetailPreview.kt
+++ b/ui-compose-material3/src/debug/java/com/github/droibit/oss_licenses/ui/compose/material3/internal/OssLicenseDetailPreview.kt
@@ -14,7 +14,7 @@ private fun OssLicenseDetailPreview() {
     Scaffold { innerPadding ->
       OssLicenseDetail(
         license = OssLicense(
-          libraryName = "OSS Licenses",
+          library = "OSS Licenses",
           text = "https://www.apache.org/licenses/LICENSE-2.0.txt",
         ),
         modifier = Modifier.padding(innerPadding),
@@ -30,7 +30,7 @@ private fun OssLicenseTextPreview() {
     Scaffold { innerPadding ->
       OssLicenseDetail(
         license = OssLicense(
-          libraryName = "OSS Licenses",
+          library = "OSS Licenses",
           text = "https://www.apache.org/licenses/LICENSE-2.0.txt",
         ),
         showLibraryName = false,

--- a/ui-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/compose/material3/internal/OssLicenseDetail.kt
+++ b/ui-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/compose/material3/internal/OssLicenseDetail.kt
@@ -28,7 +28,7 @@ internal fun OssLicenseDetail(
   ) {
     if (showLibraryName) {
       Text(
-        text = license.libraryName,
+        text = license.library,
         style = MaterialTheme.typography.titleLarge.copy(
           color = MaterialTheme.colorScheme.onSurfaceVariant,
         ),

--- a/ui-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/compose/material3/internal/OssLicenseList.kt
+++ b/ui-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/compose/material3/internal/OssLicenseList.kt
@@ -24,7 +24,7 @@ internal fun OssLicenseList(
   ) {
     items(
       licenses,
-      key = OssLicense::libraryName,
+      key = OssLicense::library,
     ) { license ->
       OssLicenseItem(
         license = license,
@@ -47,7 +47,7 @@ private fun OssLicenseItem(
 ) {
   ListItem(
     headlineContent = {
-      Text(text = license.libraryName)
+      Text(text = license.library)
     },
     modifier = modifier.clickable(
       onClick = {

--- a/ui-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/compose/material3/internal/OssLicensesTopAppBar.kt
+++ b/ui-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/compose/material3/internal/OssLicensesTopAppBar.kt
@@ -26,7 +26,7 @@ internal fun OssLicensesTopAppBar(
     title = {
       Text(
         text = if (navigator.isSinglePane()) {
-          navigator.currentDestination?.content?.libraryName
+          navigator.currentDestination?.content?.library
             ?: stringResource(id = R.string.oss_licenses_title)
         } else {
           stringResource(id = R.string.oss_licenses_title)

--- a/ui-viewmodel/src/main/java/com/github/droibit/oss_licenses/ui/viewmodel/OssLicenseViewModel.kt
+++ b/ui-viewmodel/src/main/java/com/github/droibit/oss_licenses/ui/viewmodel/OssLicenseViewModel.kt
@@ -66,6 +66,6 @@ class OssLicenseViewModel(
   @UiThread
   fun getLicense(name: String): OssLicense {
     check(licenses.value.isNotEmpty()) { "Licenses have not been loaded yet." }
-    return licenses.value.first { it.libraryName == name }
+    return licenses.value.first { it.library == name }
   }
 }

--- a/ui-wear-compose-core/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/core/OssLicenseList.kt
+++ b/ui-wear-compose-core/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/core/OssLicenseList.kt
@@ -44,7 +44,7 @@ fun OssLicenseList(
     }
     items(
       licenses,
-      key = OssLicense::libraryName,
+      key = OssLicense::library,
       itemContent = listItem,
     )
   }

--- a/ui-wear-compose-material/src/debug/java/com/github/droibit/oss_licenses/ui/wear/compose/material/internal/OssLicenseDetailScreenPreview.kt
+++ b/ui-wear-compose-material/src/debug/java/com/github/droibit/oss_licenses/ui/wear/compose/material/internal/OssLicenseDetailScreenPreview.kt
@@ -11,7 +11,7 @@ private fun OssLicenseDetailScreenShortLicensePreview() {
   MaterialTheme {
     OssLicenseDetailScreen(
       license = OssLicense(
-        libraryName = "OSS Licenses",
+        library = "OSS Licenses",
         text = "https://www.apache.org/licenses/LICENSE-2.0.txt",
       ),
     )
@@ -24,7 +24,7 @@ private fun OssLicenseDetailScreenLongLicensePreview() {
   MaterialTheme {
     OssLicenseDetailScreen(
       license = OssLicense(
-        libraryName = "The 3-Clause BSD License (BSD-3-Clause)",
+        library = "The 3-Clause BSD License (BSD-3-Clause)",
         text = """
           Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/ui-wear-compose-material/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material/internal/OssLicenseDetailScreen.kt
+++ b/ui-wear-compose-material/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material/internal/OssLicenseDetailScreen.kt
@@ -34,7 +34,7 @@ fun OssLicenseDetailScreen(
       header = {
         ListHeader {
           Text(
-            text = license.libraryName,
+            text = license.library,
             textAlign = TextAlign.Center,
             // Sets the bottom padding based on `ListHeaderDefaults.ContentPadding` in Wear Compose M3.
             modifier = Modifier.padding(bottom = 12.dp),

--- a/ui-wear-compose-material/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material/internal/OssLicenseListScreen.kt
+++ b/ui-wear-compose-material/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material/internal/OssLicenseListScreen.kt
@@ -79,7 +79,7 @@ internal fun OssLicenseItem(
       onClick(license)
     },
     label = {
-      Text(text = license.libraryName)
+      Text(text = license.library)
     },
     modifier = modifier.fillMaxWidth(),
     colors = ChipDefaults.secondaryChipColors(),

--- a/ui-wear-compose-material/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material/internal/OssLicenseNavGraph.kt
+++ b/ui-wear-compose-material/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material/internal/OssLicenseNavGraph.kt
@@ -37,7 +37,7 @@ internal fun OssLicenseNavGraph(
       OssLicenseListScreen(
         licenses = licenses,
         onNavigateToDetail = { license ->
-          navController.navigateToDetail(license.libraryName)
+          navController.navigateToDetail(license.library)
         },
       )
     }

--- a/ui-wear-compose-material3/src/debug/java/com/github/droibit/oss_licenses/ui/wear/compose/material3/internal/OssLicenseDetailScreenPreview.kt
+++ b/ui-wear-compose-material3/src/debug/java/com/github/droibit/oss_licenses/ui/wear/compose/material3/internal/OssLicenseDetailScreenPreview.kt
@@ -11,7 +11,7 @@ private fun OssLicenseDetailScreenShortLicensePreview() {
   MaterialTheme {
     OssLicenseDetailScreen(
       license = OssLicense(
-        libraryName = "OSS Licenses",
+        library = "OSS Licenses",
         text = "https://www.apache.org/licenses/LICENSE-2.0.txt",
       ),
     )
@@ -24,7 +24,7 @@ private fun OssLicenseDetailScreenLongLicensePreview() {
   MaterialTheme {
     OssLicenseDetailScreen(
       license = OssLicense(
-        libraryName = "The 3-Clause BSD License (BSD-3-Clause)",
+        library = "The 3-Clause BSD License (BSD-3-Clause)",
         text = """
           Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/ui-wear-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material3/internal/OssLicenseDetailScreen.kt
+++ b/ui-wear-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material3/internal/OssLicenseDetailScreen.kt
@@ -30,7 +30,7 @@ fun OssLicenseDetailScreen(
       header = {
         ListHeader {
           Text(
-            text = license.libraryName,
+            text = license.library,
             textAlign = TextAlign.Center,
             overflow = TextOverflow.Ellipsis,
           )

--- a/ui-wear-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material3/internal/OssLicenseListScreen.kt
+++ b/ui-wear-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material3/internal/OssLicenseListScreen.kt
@@ -83,7 +83,7 @@ internal fun OssLicenseItem(
     ),
     label = {
       Text(
-        text = license.libraryName,
+        text = license.library,
         textAlign = TextAlign.Start,
       )
     },

--- a/ui-wear-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material3/internal/OssLicenseNavGraph.kt
+++ b/ui-wear-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material3/internal/OssLicenseNavGraph.kt
@@ -42,7 +42,7 @@ internal fun OssLicenseNavGraph(
         OssLicenseListScreen(
           licenses = licenses,
           onNavigateToDetail = { license ->
-            navController.navigateToDetail(license.libraryName)
+            navController.navigateToDetail(license.library)
           },
         )
       }

--- a/ui-wear/src/main/java/com/github/droibit/oss_licenses/ui/wear/internal/OssLicenseFragment.kt
+++ b/ui-wear/src/main/java/com/github/droibit/oss_licenses/ui/wear/internal/OssLicenseFragment.kt
@@ -31,7 +31,7 @@ internal class OssLicenseFragment : Fragment(R.layout.fragment_oss_license) {
 
     val ossLicense = requireArguments().getSerializable(ARG_OSS_LICENSE) as OssLicense
     view.findViewById<TextView>(R.id.oss_name)
-      .text = ossLicense.libraryName
+      .text = ossLicense.library
     view.findViewById<TextView>(R.id.oss_license)
       .text = ossLicense.text
   }

--- a/ui-wear/src/main/java/com/github/droibit/oss_licenses/ui/wear/internal/OssLicenseListAdapter.kt
+++ b/ui-wear/src/main/java/com/github/droibit/oss_licenses/ui/wear/internal/OssLicenseListAdapter.kt
@@ -32,13 +32,13 @@ internal class OssLicenseListAdapter(
   }
 
   override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-    holder.text.text = getItem(position).libraryName
+    holder.text.text = getItem(position).library
   }
 
   companion object {
     private val DIFF_CALLBACK = object : DiffUtil.ItemCallback<OssLicense>() {
       override fun areItemsTheSame(oldItem: OssLicense, newItem: OssLicense): Boolean {
-        return oldItem.libraryName == newItem.libraryName
+        return oldItem.library == newItem.library
       }
 
       override fun areContentsTheSame(oldItem: OssLicense, newItem: OssLicense): Boolean {


### PR DESCRIPTION
This change aims to simplify the property name and maintain consistency throughout the codebase.