### PR TITLE
Add keep rules for license resources

### DIFF
--- a/parser/src/main/res/raw/oss_licenses_android_keep.xml
+++ b/parser/src/main/res/raw/oss_licenses_android_keep.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools"
+  tools:keep="@raw/third_party_license_metadata,@raw/third_party_licenses" />


### PR DESCRIPTION
Ensure `third_party_license_metadata` and `third_party_licenses` raw resources are preserved   
when apps enable resource shrinking.