### PR TITLE
Move responsive padding utilities to Material3 module

### DIFF
--- a/ui-wear-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material3/internal/ResponsiveColumnPadding.kt
+++ b/ui-wear-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material3/internal/ResponsiveColumnPadding.kt
@@ -1,4 +1,4 @@
-package com.github.droibit.oss_licenses.ui.wear.compose.core
+package com.github.droibit.oss_licenses.ui.wear.compose.material3.internal
 
 import androidx.annotation.RestrictTo
 import androidx.compose.foundation.layout.PaddingValues

--- a/ui-wear-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material3/internal/detail/OssLicenseDetail.kt
+++ b/ui-wear-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material3/internal/detail/OssLicenseDetail.kt
@@ -13,7 +13,7 @@ import androidx.wear.compose.material3.ListHeader
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
 import com.github.droibit.oss_licenses.parser.OssLicense
-import com.github.droibit.oss_licenses.ui.wear.compose.core.rememberResponsiveColumnPadding
+import com.github.droibit.oss_licenses.ui.wear.compose.material3.internal.rememberResponsiveColumnPadding
 
 @Composable
 internal fun OssLicenseDetail(

--- a/ui-wear-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material3/internal/list/OssLicenseList.kt
+++ b/ui-wear-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material3/internal/list/OssLicenseList.kt
@@ -9,7 +9,7 @@ import androidx.wear.compose.foundation.lazy.TransformingLazyColumnState
 import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
 import com.github.droibit.oss_licenses.parser.OssLicense
-import com.github.droibit.oss_licenses.ui.wear.compose.core.rememberResponsiveColumnPadding
+import com.github.droibit.oss_licenses.ui.wear.compose.material3.internal.rememberResponsiveColumnPadding
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Composable


### PR DESCRIPTION
- Move ResponsiveColumnPadding.kt to `ui-wear-compose-material3` module

Note: Padding values are designed for TransformingLazyColumn, making them more appropriate in the Material3 module rather than the core module.