### PR TITLE
Restrict composable visibility to internal

### DIFF
--- a/ui-wear-compose-material/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material/internal/detail/OssLicenseDetail.kt
+++ b/ui-wear-compose-material/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material/internal/detail/OssLicenseDetail.kt
@@ -29,7 +29,7 @@ import kotlin.math.sqrt
 
 @OptIn(ExperimentalWearFoundationApi::class)
 @Composable
-fun OssLicenseDetail(
+internal fun OssLicenseDetail(
   license: OssLicense,
   modifier: Modifier = Modifier,
   listState: LazyListState = rememberLazyListState(),

--- a/ui-wear-compose-material/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material/internal/detail/OssLicenseDetailScreen.kt
+++ b/ui-wear-compose-material/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material/internal/detail/OssLicenseDetailScreen.kt
@@ -9,7 +9,7 @@ import androidx.wear.compose.material.Scaffold
 import com.github.droibit.oss_licenses.parser.OssLicense
 
 @Composable
-fun OssLicenseDetailScreen(
+internal fun OssLicenseDetailScreen(
   license: OssLicense,
   modifier: Modifier = Modifier,
   listState: LazyListState = rememberLazyListState(),

--- a/ui-wear-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material3/internal/ResponsiveColumnPadding.kt
+++ b/ui-wear-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material3/internal/ResponsiveColumnPadding.kt
@@ -1,6 +1,5 @@
 package com.github.droibit.oss_licenses.ui.wear.compose.material3.internal
 
-import androidx.annotation.RestrictTo
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalConfiguration
@@ -9,9 +8,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlin.math.ceil
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Composable
-fun rememberResponsiveColumnPadding(): PaddingValues {
+internal fun rememberResponsiveColumnPadding(): PaddingValues {
   val configuration = LocalConfiguration.current
   val screenHeightDp = configuration.screenHeightDp.dp
   val screenWidthDp = configuration.screenWidthDp.dp

--- a/ui-wear-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material3/internal/detail/OssLicenseDetailScreen.kt
+++ b/ui-wear-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material3/internal/detail/OssLicenseDetailScreen.kt
@@ -8,7 +8,7 @@ import androidx.wear.compose.material3.ScreenScaffold
 import com.github.droibit.oss_licenses.parser.OssLicense
 
 @Composable
-fun OssLicenseDetailScreen(
+internal fun OssLicenseDetailScreen(
   license: OssLicense,
   modifier: Modifier = Modifier,
   listState: TransformingLazyColumnState = rememberTransformingLazyColumnState(),

--- a/ui-wear-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material3/internal/list/OssLicenseList.kt
+++ b/ui-wear-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material3/internal/list/OssLicenseList.kt
@@ -1,6 +1,5 @@
 package com.github.droibit.oss_licenses.ui.wear.compose.material3.internal.list
 
-import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
@@ -11,9 +10,8 @@ import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
 import com.github.droibit.oss_licenses.parser.OssLicense
 import com.github.droibit.oss_licenses.ui.wear.compose.material3.internal.rememberResponsiveColumnPadding
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Composable
-fun OssLicenseList(
+internal fun OssLicenseList(
   licenses: List<OssLicense>,
   header: @Composable TransformingLazyColumnItemScope.() -> Unit,
   listItem: @Composable TransformingLazyColumnItemScope.(OssLicense) -> Unit,


### PR DESCRIPTION
- Mark Wear Material/Material3 composables as internal
- Remove unnecessary `@RestrictTo` annotations
- Apply to detail screens and list components