### PR TITLE
Add Kotlin compatibility settings for library modules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.BasePlugin
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 buildscript {
@@ -65,6 +66,12 @@ subprojects {
   tasks.withType<KotlinJvmCompile>().configureEach {
     compilerOptions {
       jvmTarget.set(JvmTarget.JVM_17)
+
+      // Align with Jetpack Compose's Kotlin compatibility requirements.
+      plugins.withId(libs.plugins.android.library.get().pluginId) {
+        apiVersion.set(KotlinVersion.KOTLIN_1_9)
+        languageVersion.set(KotlinVersion.KOTLIN_1_9)
+      }
     }
   }
 }


### PR DESCRIPTION
- Set Kotlin API and language version to 1.9 for library modules
- Align Kotlin version with Jetpack Compose requirements