### PR TITLE
Unify root UI to `OssLicensesApp`

### DIFF
--- a/ui-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/compose/material3/OssLicensesActivity.kt
+++ b/ui-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/compose/material3/OssLicensesActivity.kt
@@ -6,7 +6,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import com.github.droibit.oss_licenses.ui.compose.material3.internal.OssLicensesScreen
+import com.github.droibit.oss_licenses.ui.compose.material3.internal.OssLicensesApp
 import com.github.droibit.oss_licenses.ui.compose.material3.internal.OssLicensesTheme
 
 /**
@@ -19,7 +19,7 @@ class OssLicensesActivity : ComponentActivity() {
 
     setContent {
       OssLicensesTheme {
-        OssLicensesScreen()
+        OssLicensesApp()
       }
     }
   }

--- a/ui-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/compose/material3/internal/OssLicensesApp.kt
+++ b/ui-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/compose/material3/internal/OssLicensesApp.kt
@@ -20,7 +20,7 @@ import com.github.droibit.oss_licenses.ui.viewmodel.OssLicenseViewModel
 
 @OptIn(ExperimentalMaterial3AdaptiveApi::class)
 @Composable
-internal fun OssLicensesScreen(
+internal fun OssLicensesApp(
   modifier: Modifier = Modifier,
   viewModel: OssLicenseViewModel = viewModel(),
 ) {

--- a/ui-wear-compose-material/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material/WearableOssLicensesActivity.kt
+++ b/ui-wear-compose-material/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material/WearableOssLicensesActivity.kt
@@ -6,7 +6,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.wear.compose.material.MaterialTheme
-import com.github.droibit.oss_licenses.ui.wear.compose.material.internal.OssLicenseNavGraph
+import com.github.droibit.oss_licenses.ui.wear.compose.material.internal.OssLicensesApp
 
 /**
  * An activity that displays open source licenses.
@@ -17,7 +17,7 @@ class WearableOssLicensesActivity : ComponentActivity() {
 
     setContent {
       MaterialTheme {
-        OssLicenseNavGraph()
+        OssLicensesApp()
       }
     }
   }

--- a/ui-wear-compose-material/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material/internal/OssLicensesApp.kt
+++ b/ui-wear-compose-material/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material/internal/OssLicensesApp.kt
@@ -19,7 +19,7 @@ import com.github.droibit.oss_licenses.ui.wear.compose.navigation.Routes.License
 import com.github.droibit.oss_licenses.ui.wear.compose.navigation.navigateToDetail
 
 @Composable
-internal fun OssLicenseNavGraph(
+internal fun OssLicensesApp(
   modifier: Modifier = Modifier,
   navController: NavHostController = rememberSwipeDismissableNavController(),
   viewModel: OssLicenseViewModel = viewModel(),

--- a/ui-wear-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material3/WearableOssLicensesActivity.kt
+++ b/ui-wear-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material3/WearableOssLicensesActivity.kt
@@ -6,7 +6,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.wear.compose.material3.MaterialTheme
-import com.github.droibit.oss_licenses.ui.wear.compose.material3.internal.OssLicenseNavGraph
+import com.github.droibit.oss_licenses.ui.wear.compose.material3.internal.OssLicensesApp
 
 /**
  * An activity that displays open source licenses.
@@ -17,7 +17,7 @@ class WearableOssLicensesActivity : ComponentActivity() {
 
     setContent {
       MaterialTheme {
-        OssLicenseNavGraph()
+        OssLicensesApp()
       }
     }
   }

--- a/ui-wear-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material3/internal/OssLicensesApp.kt
+++ b/ui-wear-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/wear/compose/material3/internal/OssLicensesApp.kt
@@ -20,7 +20,7 @@ import com.github.droibit.oss_licenses.ui.wear.compose.navigation.Routes.License
 import com.github.droibit.oss_licenses.ui.wear.compose.navigation.navigateToDetail
 
 @Composable
-internal fun OssLicenseNavGraph(
+internal fun OssLicensesApp(
   modifier: Modifier = Modifier,
   navController: NavHostController = rememberSwipeDismissableNavController(),
   viewModel: OssLicenseViewModel = viewModel(),


### PR DESCRIPTION
This pull request includes changes to rename the `OssLicensesScreen` and `OssLicenseNavGraph` components to `OssLicensesApp` across multiple files for consistency.