### PR TITLE
Add content filtering for Google repository

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -2,7 +2,13 @@
 
 dependencyResolutionManagement {
   repositories {
-    google()
+    google {
+      content {
+        includeGroupByRegex("com\\.android.*")
+        includeGroupByRegex("com\\.google.*")
+        includeGroupByRegex("androidx.*")
+      }
+    }
     mavenCentral()
   }
   versionCatalogs {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,9 +3,15 @@
 pluginManagement {
   includeBuild("build-logic")
   repositories {
-    google()
-    gradlePluginPortal()
+    google {
+      content {
+        includeGroupByRegex("com\\.android.*")
+        includeGroupByRegex("com\\.google.*")
+        includeGroupByRegex("androidx.*")
+      }
+    }
     mavenCentral()
+    gradlePluginPortal()
   }
 
   // https://github.com/google/play-services-plugins/issues/223
@@ -22,7 +28,13 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 dependencyResolutionManagement {
   repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
   repositories {
-    google()
+    google {
+      content {
+        includeGroupByRegex("com\\.android.*")
+        includeGroupByRegex("com\\.google.*")
+        includeGroupByRegex("androidx.*")
+      }
+    }
     mavenCentral()
   }
 }


### PR DESCRIPTION
- Restrict Google repository to only include official Android dependencies:
  - `com.android.*`: Android build tools and SDK
  - `com.google.*`: Google libraries
  - `androidx.*`: AndroidX libraries
- Apply filtering in:
  - Main project's settings.gradle.kts
  - build-logic's settings.gradle.kts