### PR TITLE
Fix scroll position reset in `OssLicenseList` on compact devices

### DIFF
--- a/ui-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/compose/material3/internal/OssLicenseList.kt
+++ b/ui-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/compose/material3/internal/OssLicenseList.kt
@@ -4,7 +4,9 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.Text
@@ -17,9 +19,11 @@ import com.github.droibit.oss_licenses.parser.OssLicense
 internal fun OssLicenseList(
   licenses: List<OssLicense>,
   modifier: Modifier = Modifier,
+  listState: LazyListState = rememberLazyListState(),
   onItemClick: (OssLicense) -> Unit = {},
 ) {
   LazyColumn(
+    state = listState,
     modifier = modifier,
   ) {
     items(

--- a/ui-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/compose/material3/internal/OssLicensesPaneContent.kt
+++ b/ui-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/compose/material3/internal/OssLicensesPaneContent.kt
@@ -1,5 +1,7 @@
 package com.github.droibit.oss_licenses.ui.compose.material3.internal
 
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
 import androidx.compose.material3.adaptive.layout.AnimatedPane
 import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffold
@@ -15,6 +17,7 @@ import com.github.droibit.oss_licenses.parser.OssLicense
 internal fun OssLicensesPaneContent(
   licenses: List<OssLicense>,
   modifier: Modifier = Modifier,
+  listState: LazyListState = rememberLazyListState(),
   navigator: ThreePaneScaffoldNavigator<OssLicense> =
     rememberListDetailPaneScaffoldNavigator<OssLicense>(),
 ) {
@@ -26,6 +29,7 @@ internal fun OssLicensesPaneContent(
       AnimatedPane {
         OssLicenseList(
           licenses = licenses,
+          listState = listState,
           onItemClick = { license ->
             navigator.navigateTo(ListDetailPaneScaffoldRole.Detail, license)
           },


### PR DESCRIPTION
This fixes the issue where the license list scroll position was reset when navigating back from detail view on Compact devices.