### PR TITLE
Improve TopAppBar title display for license details

### DIFF
--- a/ui-compose-material3/src/debug/java/com/github/droibit/oss_licenses/ui/compose/material3/internal/OssLicensesPaneContentPreview.kt
+++ b/ui-compose-material3/src/debug/java/com/github/droibit/oss_licenses/ui/compose/material3/internal/OssLicensesPaneContentPreview.kt
@@ -21,17 +21,24 @@ internal fun OssLicensesPaneContentPreview() {
       OssLicenseUiState("license-3", "kotlinx-coroutines-android", ""),
       OssLicenseUiState("license-4", "wear-compose", ""),
       OssLicenseUiState(
-        "license-5",
-        "The MIT License",
-        """
-        Copyright <YEAR> <COPYRIGHT HOLDER>
+        id = "license-5",
+        library = "OSS Licenses Android",
+        licenseText =
+          """
+            Copyright (C) 2018 Shinya Kumagai
 
-        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+            Licensed under the Apache License, Version 2.0 (the "License");
+            you may not use this file except in compliance with the License.
+            You may obtain a copy of the License at
 
-        The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+                http://www.apache.org/licenses/LICENSE-2.0
 
-        THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-        """.trimIndent(),
+            Unless required by applicable law or agreed to in writing, software
+            distributed under the License is distributed on an "AS IS" BASIS,
+            WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+            See the License for the specific language governing permissions and
+            limitations under the License.
+            """.trimIndent(),
       ),
     )
     val navigator = rememberListDetailPaneScaffoldNavigator<OssLicenseUiState>()

--- a/ui-compose-material3/src/debug/java/com/github/droibit/oss_licenses/ui/compose/material3/internal/OssLicensesPaneContentPreview.kt
+++ b/ui-compose-material3/src/debug/java/com/github/droibit/oss_licenses/ui/compose/material3/internal/OssLicensesPaneContentPreview.kt
@@ -25,20 +25,20 @@ internal fun OssLicensesPaneContentPreview() {
         library = "OSS Licenses Android",
         licenseText =
           """
-            Copyright (C) 2018 Shinya Kumagai
+          Copyright (C) 2018 Shinya Kumagai
 
-            Licensed under the Apache License, Version 2.0 (the "License");
-            you may not use this file except in compliance with the License.
-            You may obtain a copy of the License at
+          Licensed under the Apache License, Version 2.0 (the "License");
+          you may not use this file except in compliance with the License.
+          You may obtain a copy of the License at
 
-                http://www.apache.org/licenses/LICENSE-2.0
+              http://www.apache.org/licenses/LICENSE-2.0
 
-            Unless required by applicable law or agreed to in writing, software
-            distributed under the License is distributed on an "AS IS" BASIS,
-            WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-            See the License for the specific language governing permissions and
-            limitations under the License.
-            """.trimIndent(),
+          Unless required by applicable law or agreed to in writing, software
+          distributed under the License is distributed on an "AS IS" BASIS,
+          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+          See the License for the specific language governing permissions and
+          limitations under the License.
+          """.trimIndent(),
       ),
     )
     val navigator = rememberListDetailPaneScaffoldNavigator<OssLicenseUiState>()

--- a/ui-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/compose/material3/internal/OssLicensesTopAppBar.kt
+++ b/ui-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/compose/material3/internal/OssLicensesTopAppBar.kt
@@ -26,10 +26,13 @@ internal fun OssLicensesTopAppBar(
   CenterAlignedTopAppBar(
     title = {
       Text(
-        text = navigator.currentDestination?.content?.library?.takeIf { navigator.isSinglePane() }
+        text = navigator.currentDestination
+          ?.content
+          ?.library
+          ?.takeIf { navigator.isSinglePane() }
           ?: stringResource(id = R.string.oss_licenses_title),
         overflow = TextOverflow.Ellipsis,
-        maxLines = 1
+        maxLines = 1,
       )
     },
     navigationIcon = {

--- a/ui-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/compose/material3/internal/OssLicensesTopAppBar.kt
+++ b/ui-compose-material3/src/main/java/com/github/droibit/oss_licenses/ui/compose/material3/internal/OssLicensesTopAppBar.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.adaptive.navigation.ThreePaneScaffoldNavigator
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import com.github.droibit.oss_licenses.ui.OssLicenseUiState
 import com.github.droibit.oss_licenses.ui.compose.material3.R
 
@@ -25,12 +26,10 @@ internal fun OssLicensesTopAppBar(
   CenterAlignedTopAppBar(
     title = {
       Text(
-        text = if (navigator.isSinglePane()) {
-          navigator.currentDestination?.content?.library
-            ?: stringResource(id = R.string.oss_licenses_title)
-        } else {
-          stringResource(id = R.string.oss_licenses_title)
-        },
+        text = navigator.currentDestination?.content?.library?.takeIf { navigator.isSinglePane() }
+          ?: stringResource(id = R.string.oss_licenses_title),
+        overflow = TextOverflow.Ellipsis,
+        maxLines = 1
       )
     },
     navigationIcon = {
@@ -51,7 +50,7 @@ internal fun BackNavigationButton(
   ) {
     Icon(
       imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
-      contentDescription = null,
+      contentDescription = "Back",
     )
   }
 }


### PR DESCRIPTION
This change ensures the TopAppBar maintains a clean appearance even with very long library names by truncating text with ellipsis when necessary.